### PR TITLE
Add new sections and guidelines to root README template

### DIFF
--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -1,16 +1,65 @@
 # {{cookiecutter.project_name}}
 
-## Setup
+**_Change this to the full project name 👆_**
 
-- Meet the data science cookiecutter [requirements](http://nestauk.github.io/ds-cookiecutter/quickstart), in brief:
-  - Install: `direnv` and `conda`
+**_Add a one-liner that describes this project._**
+
+## 👋 Welcome!
+
+**_Write a longer description of the project here. Put what you like here, but you might want to include:_**
+
+- **_Some background on the project and what its aims are_**
+- **_A high level description of what the code in this repository does_**
+- **_Links to other relevant work or information on Nesta's website_**
+- **_The respository's development status. Is this currently under development, finished, parked (offer an explanation if you feel it is needed)._**
+- **_Link to any particularly important project outputs:_**
+  - **_reports_**
+  - **_slide decks_**
+  - **_media_**
+
+![Maybe add an image or nice graphic relating to the project here.](https://betterimagesofai.org/ImagesAI/WarburtonNature_01_1280x720.jpg "Adding an image title is optional. This one is by Alan Warburton / © BBC / Better Images of AI / Plant / CC-BY 4.0")
+
+## 📂 Contents
+
+**_Write a high level outline of the repository contents and structure. What are the main functions and outputs and where can the reader find them? This is not a replacement for informative readmes in sub-directories!_**
+
+## 🛠️ Setup and installation
+
+**Step 1.** Check that you meet the [data science cookiecutter requirements](http://nestauk.github.io/ds-cookiecutter/quickstart). In brief:
+
+Install the following components:
+  - [gh](https://formulae.brew.sh/formula/gh) - GitHub command line tool.
+  - [direnv](https://formulae.brew.sh/formula/direnv#default) - For using environment variables.
+  - [git-crypt](https://github.com/AGWA/git-crypt/blob/master/INSTALL.md#installing-on-mac-os-x) - Tool for encryption of sensitive files.
+
+Have a Nesta AWS account, and install and configure your [AWS Command Line Interface](https://docs.aws.amazon.com/polly/latest/dg/setup-aws-cli.html)
+
+**Step 2.** Setup other dependencies.
+
+**_Are there any other dependencies that this project requires?_**
+
+
+**Step 3.** Install, configure and activate the environment for this project on your machine.
+
 - Run `make install` to configure the development environment:
   - Setup the conda environment
   - Configure `pre-commit`
 
-## Contributor guidelines
+Activate the newly created conda environment.
 
-[Technical and working style guidelines](https://github.com/nestauk/ds-cookiecutter/blob/master/GUIDELINES.md)
+## 💾 Datasets
+
+**_List and describe any datasets used in the project. If possible link to them or a page that describes them. If special requirements are needed to access them, this might be a good place to explain._**
+
+
+## 🤝 Contributor guidelines
+
+[Nesta's technical and working style guidelines for data scientists](https://github.com/nestauk/ds-cookiecutter/blob/master/GUIDELINES.md)
+
+
+## 📧 Get in touch
+
+If you want people to reach out about the work, put relevant email addresses here or instructions on how to leave an issue (only do this if you expect that you or someone will respond).
 
 ---
 

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -17,7 +17,7 @@
   - **_slide decks_**
   - **_media_**
 
-![Maybe add an image or nice graphic relating to the project here.](https://betterimagesofai.org/ImagesAI/WarburtonNature_01_1280x720.jpg "Adding an image title is optional. This one is by Alan Warburton / © BBC / Better Images of AI / Plant / CC-BY 4.0")
+![Maybe add an image or nice graphic relating to the project here. This one is by Alan Warburton / © BBC / Better Images of AI / Plant / CC-BY 4.0](https://betterimagesofai.org/ImagesAI/WarburtonNature_01_1280x720.jpg)
 
 ## 📂 Contents
 
@@ -56,6 +56,9 @@ Activate the newly created conda environment with `conda activate {{ cookiecutte
 
 **_List and describe any datasets used in the project. If possible link to them or a page that describes them. If special requirements are needed to access them, this might be a good place to explain._**
 
+## 🏁 Testing
+
+**_If this project has tests, explain how to run them here._**
 
 ## 🤝 Contributor guidelines
 
@@ -64,7 +67,7 @@ Activate the newly created conda environment with `conda activate {{ cookiecutte
 
 ## 📧 Get in touch
 
-If you want people to reach out about the work, put relevant email addresses here or instructions on how to leave an issue (only do this if you expect that you or someone will respond).
+**_If you want people to reach out about the work, put relevant email addresses here or instructions on how to leave an issue (only do this if you expect that you or someone will respond)._**
 
 ---
 

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -41,11 +41,16 @@ Have a Nesta AWS account, and install and configure your [AWS Command Line Inter
 
 **Step 3.** Install, configure and activate the environment for this project on your machine.
 
-- Run `make install` to configure the development environment:
-  - Setup the conda environment
-  - Configure `pre-commit`
+Create a blank cookiecutter conda log file:
+```
+$ mkdir .cookiecutter/state
+$ touch .cookiecutter/state/conda-create.log
+```
+Run `make install` to configure the development environment:
+- Setup the conda environment
+- Configure `pre-commit`
 
-Activate the newly created conda environment.
+Activate the newly created conda environment with `conda activate {{ cookiecutter.project_name }}`
 
 ## 💾 Datasets
 


### PR DESCRIPTION
I have updated the project root README to provide a template and guidance for writing a useful and informative introduction to a project. The approach I have taken is quite verbose but has the advantage of providing the user with a substantial description of what might go in each section, which could be particularly useful for newer team members.

For inspiration, I have used the READMEs of:
- [Innovation Sweet Spots](https://github.com/nestauk/innovation_sweet_spots)
- [Gender Bias in Computer Science](https://github.com/nestauk/comp_sci_gender_bias/)
- [Open Jobs Skills](https://github.com/nestauk/ojd_daps_skills)

I'm not completely settled on this approach - some quetsions I have are:
- Should there be some instructions at the top for how to use the readme?
- Is this too verbose? Would a better approach be to just have a checkbox list at the top with possible sections and one sentence on what to put in them. (This would be neater, but leaves more overhead for users and has a higher risk of just being ignored imo.)


---

closes #142 
closes #139 
