### PR TITLE
adding make directory command to makefile template

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -14,6 +14,10 @@ export
 # Import config variables
 include .cookiecutter/config
 
+# Ensure directory to track and log setup state exists
+$(shell mkdir -p .cookiecutter/state)
+$(shell touch .cookiecutter/state/conda-create.log)
+
 .PHONY: install
 ## Install a project: create conda env; install local package; setup git hooks
 install: .cookiecutter/state/conda-create .cookiecutter/state/setup-git


### PR DESCRIPTION
This PR closes #145 by adding 2 lines to the makefile to create the state directory and log file. 

The bug was that .cookiecutter/state is included in the .gitignore so when users were running make install for existing repositories there was an error that it couldn't find the log file. This error was not encountered on initial creation because .cookiecutter/state is included in the original setup structure.

This fix will enable users to recreate existing repositories going forward. However, any existing projects will still have the issue unless they change their makefile. 
