### PR TITLE
Updated makefile suppressing output conda-remove

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -61,8 +61,8 @@ pip-install:
 .PHONY: conda-remove
 ## Remove the conda-environment cleanly, using -f so works even if no environment to be removed
 conda-remove:
-	conda env remove -n ${REPO_NAME}
-	rm -f .cookiecutter/state/conda-create*
+	@conda env remove -n ${REPO_NAME}
+	@rm -f .cookiecutter/state/conda-create*
 	@direnv reload
 
 .PHONY: clean


### PR DESCRIPTION
Added output suppression for conda-remove so that when it runs as pre-req for install it does give weird messages.

---

Checklist:

- [ ] Updated documentation
- [ ] CI passes
- [ ] Labelled PR major/minor/patch
