### PR TITLE
chore(hooks): move nbstripout hook for stripping notebook outputs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,3 @@ repos:
       - id: prettier
         name: Prettier (except markdown)
         exclude: ".md"
-  - repo: https://github.com/kynan/nbstripout
-    rev: 0.6.1
-    hooks:
-      - id: nbstripout

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -59,3 +59,7 @@ repos:
     rev: v2.1.2
     hooks:
       - id: prettier
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.6.1
+    hooks:
+      - id: nbstripout


### PR DESCRIPTION
---
nbstripout pre-commit hook was placed in incorrect directory. This PR patches this issue by moving the hook to the correct templated subfolder.

Checklist:

- [ ] Updated documentation - not needed
- [x] CI passes
- [x] Labelled PR major/minor/patch
