### PR TITLE
build: remove defaults channel

### DIFF
--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -192,6 +192,7 @@ class TestCookieSetup(object):
     def test_install(self):
         """Test `make install` command."""
         with ch_dir(self.path):
+            shell(["conda", "deactivate"])
             shell(["make", "install"])
 
             output = "".join(shell(["bash", "-c", "source .envrc && which python"]))

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -192,7 +192,6 @@ class TestCookieSetup(object):
     def test_install(self):
         """Test `make install` command."""
         with ch_dir(self.path):
-            shell(["conda", "deactivate"])
             shell(["make", "install"])
 
             output = "".join(shell(["bash", "-c", "source .envrc && which python"]))

--- a/{{ cookiecutter.repo_name }}/environment.yaml
+++ b/{{ cookiecutter.repo_name }}/environment.yaml
@@ -1,4 +1,5 @@
 channels:
+  - nodefaults
   - conda-forge
 dependencies:
   - pip

--- a/{{ cookiecutter.repo_name }}/environment.yaml
+++ b/{{ cookiecutter.repo_name }}/environment.yaml
@@ -1,5 +1,4 @@
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - pip


### PR DESCRIPTION
---
Removes defaults channel from conda related cookiecutter projects


Checklist:

- [ ] Updated documentation (not applicable)
- [x] CI passes
- [x] Labelled PR major/minor/patch
