### PR TITLE
Improve pre-commit-config.yaml to utilise versioned repos rather than local

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,56 +1,23 @@
 repos:
-  - repo: local
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
-        name: Check for added large files
-        entry: check-added-large-files
-        language: system
       - id: check-merge-conflict
-        name: Check for files with merge conflict strings
-        entry: check-merge-conflict
-        language: system
       - id: end-of-file-fixer
-        name: Fix End of Files
-        entry: end-of-file-fixer
-        language: system
-        types: [text]
-        stages: [commit, push, manual]
       - id: trailing-whitespace
-        name: Trim Trailing Whitespace
-        entry: trailing-whitespace-fixer
-        language: system
-        types: [text]
-        stages: [commit, push, manual]
       - id: check-toml
-        name: Check Toml
-        entry: check-toml
-        language: system
-        types: [toml]
       - id: check-yaml
-        name: Check Yaml
-        entry: check-yaml
-        language: system
         exclude: "docs/mkdocs.yml"
-        types: [yaml]
       - id: no-commit-to-branch
-        name: Prevent commits to dev / master
-        entry: no-commit-to-branch
-        language: python
         args: ["-b", dev, "-b", master, "-b", main]
         pass_filenames: false
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.8.0
+    hooks:
       - id: black
-        name: black
-        entry: black
-        language: system
-        types: [python]
+        language_version: python3.10
         require_serial: true
-      # - id: flake8
-      #   name: flake8
-      #   entry: flake8
-      #   language: system
-      #   types: [python]
-      #   args: ["--config='{{ cookiecutter.repo_name }}/setup.cfg'"]
-      #   require_serial: true
   - repo: https://github.com/prettier/pre-commit
     rev: v2.1.2
     hooks:

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -1,60 +1,23 @@
 repos:
-  - repo: local
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
     hooks:
-      - id: black
-        name: black
-        entry: black
-        language: system
-        types: [python]
-        require_serial: true
       - id: check-added-large-files
-        name: Check for added large files
-        entry: check-added-large-files
-        language: system
       - id: check-merge-conflict
-        name: Check for files with merge conflict strings
-        entry: check-merge-conflict
-        language: system
       - id: end-of-file-fixer
-        name: Fix End of Files
-        entry: end-of-file-fixer
-        language: system
-        types: [text]
-        stages: [commit, push, manual]
       - id: trailing-whitespace
-        name: Trim Trailing Whitespace
-        entry: trailing-whitespace-fixer
-        language: system
-        types: [text]
-        stages: [commit, push, manual]
       - id: check-toml
-        name: Check Toml
-        entry: check-toml
-        language: system
-        types: [toml]
       - id: check-yaml
-        name: Check Yaml
-        entry: check-yaml
-        language: system
-        types: [yaml]
-      # - id: reorder-python-imports
-      #   name: Reorder python imports
-      #   entry: reorder-python-imports
-      #   language: system
-      #   types: [python]
-      # - id: flake8
-      #   name: flake8
-      #   entry: flake8
-      #   language: system
-      #   types: [python]
-      #   args: ["--config=.flake8"]
-      #   require_serial: true
+        exclude: "docs/mkdocs.yml"
       - id: no-commit-to-branch
-        name: Prevent commits to dev / master
-        entry: no-commit-to-branch
-        language: python
         args: ["-b", dev, "-b", master, "-b", main]
         pass_filenames: false
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.8.0
+    hooks:
+      - id: black
+        language_version: python3.10
+        require_serial: true
   - repo: https://github.com/prettier/pre-commit
     rev: v2.1.2
     hooks:


### PR DESCRIPTION
Resolves #193 by updating the pre-commit-config yaml files to use versioned repos. Local is a bad idea for reproducibility and it leads to excessive dependency trees. The performance will be a lot better once we use ruff etc. anyway and in general pre commit hooks should be kept to a minimum. This PR does not aim to tackle that, just update the way in which pre-commit hooks are installed.

---

Checklist:

- [ ] Updated documentation
- [ ] CI passes
- [ ] Labelled PR major/minor/patch
