### PR TITLE
Support for `conda`, `venv` or `pyenv-virtualenv` usage in cookiecutter

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,5 +3,13 @@
   "repo_name": "{{ cookiecutter.project_name.lstrip('0123456789.- ').replace(' ', '_').replace('-', '_').lower() }}",
   "author_name": "Nesta",
   "description": "A short description of the project.",
-  "openness": ["public", "private"]
+  "openness": [
+    "public",
+    "private"
+  ],
+  "venv_type": [
+    "conda",
+    "venv",
+    "pyenv-virtualenv"
+  ]
 }

--- a/{{ cookiecutter.repo_name }}/.cookiecutter/config
+++ b/{{ cookiecutter.repo_name }}/.cookiecutter/config
@@ -3,3 +3,33 @@ export PROJECT_NAME={{ cookiecutter.project_name }}
 export REPO_NAME={{ cookiecutter.repo_name }}
 export DESCRIPTION={{ cookiecutter.description }}
 export PROJECT_OPENNESS={{ cookiecutter.openness }}
+export ENVIRONMENT_TYPE={{ cookiecutter.venv_type }}
+
+{% if cookiecutter.venv_type == 'conda' %}
+# Conda configuration
+ENVIRONMENT_NAME=${REPO_NAME}
+ENV_CREATE=conda env create -n ${ENVIRONMENT_NAME} -f environment.yaml
+ENV_ACTIVATE=conda activate ${ENVIRONMENT_NAME}
+ENV_DEACTIVATE=conda deactivate
+ENV_REMOVE=conda env remove -n ${ENVIRONMENT_NAME}
+ENV_UPDATE=conda env update -n ${ENVIRONMENT_NAME} -f environment.yaml
+ENV_INSTALL_EXTRAS=conda install pip
+{% elif cookiecutter.venv_type == 'venv' %}
+# venv configuration
+VENV_PATH=.venv
+ENV_CREATE=python -m venv ${VENV_PATH}
+ENV_ACTIVATE=source ${VENV_PATH}/bin/activate
+ENV_DEACTIVATE=deactivate
+ENV_REMOVE=rm -rf ${VENV_PATH}
+ENV_UPDATE=pip install -r requirements.txt
+ENV_INSTALL_EXTRAS=true
+{% else %}
+# pyenv-virtualenv configuration
+ENVIRONMENT_NAME=${REPO_NAME}
+ENV_CREATE=pyenv virtualenv ${PYTHON_VERSION} ${ENVIRONMENT_NAME}
+ENV_ACTIVATE=pyenv activate ${ENVIRONMENT_NAME}
+ENV_DEACTIVATE=pyenv deactivate
+ENV_REMOVE=pyenv virtualenv-delete ${ENVIRONMENT_NAME}
+ENV_UPDATE=pip install -r requirements.txt
+ENV_INSTALL_EXTRAS=true
+{% endif %}

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -14,14 +14,36 @@ export
 # Import config variables
 include .cookiecutter/config
 
+# Environment type detection
+ENVIRONMENT_TYPE ?= venv
+
+# Virtual environment configuration
+# These can be overridden through environment variables or .envrc
+# Example for pyenv-virtualenv users:
+#   export VENV_PATH=${PYENV_ROOT}/versions/${REPO_NAME}
+#   export VENV_CREATE_CMD="pyenv virtualenv ${PYTHON_VERSION} ${REPO_NAME}"
+#   export VENV_ACTIVATE_CMD="pyenv activate ${REPO_NAME}"
+#   export VENV_DEACTIVATE_CMD="pyenv deactivate"
+VENV_PATH ?= .venv
+VENV_CREATE_CMD ?= python -m venv ${VENV_PATH}
+VENV_ACTIVATE_CMD ?= source ${VENV_PATH}/bin/activate
+VENV_DEACTIVATE_CMD ?= deactivate
+VENV_REMOVE_CMD ?= rm -rf ${VENV_PATH}
+
 # Ensure directory to track and log setup state exists
 $(shell mkdir -p .cookiecutter/state)
 $(shell touch .cookiecutter/state/conda-create.log)
+$(shell touch .cookiecutter/state/venv-create.log)
 
 .PHONY: install
-## Install a project: remove existing conda env (if exists); create conda env; install local package; setup git hooks
-install: conda-remove .cookiecutter/state/conda-create .cookiecutter/state/setup-git
-	@direnv reload  # Now the conda env exists, reload to activate it
+## Install a project: setup environment, install dependencies, and configure git hooks
+install:
+ifeq ($(ENVIRONMENT_TYPE),conda)
+	$(MAKE) conda-remove .cookiecutter/state/conda-create .cookiecutter/state/setup-git
+else
+	$(MAKE) venv-remove .cookiecutter/state/venv-create .cookiecutter/state/setup-git
+endif
+	@direnv reload  # Reload to activate the environment
 
 
 .PHONY: check-bucket-path
@@ -84,6 +106,25 @@ define err
 	(echo "$1, check $@.log for more info" && exit 1)
 endef
 
+.PHONY: venv-remove
+## Remove the virtual environment cleanly
+venv-remove:
+	rm -rf ${VENV_PATH}
+	rm -f .cookiecutter/state/venv-create*
+	@direnv reload
+
+.cookiecutter/state/venv-create:
+	@echo -n "Creating virtual environment and installing dependencies"
+	@( \
+		$(VENV_CREATE_CMD) && \
+		$(VENV_ACTIVATE_CMD) && \
+		pip install -r requirements.txt && \
+		pip install -e ".[dev]" \
+	) > $@.log 2>&1 \
+	|| $(call err,Python environment setup failed)
+	@touch $@
+	@echo " DONE"
+
 .cookiecutter/state/conda-create:
 	@echo -n "Creating environment ${REPO_NAME} and installing all dependencies"
 	@(conda env create -q -n ${REPO_NAME} -f environment.yaml\
@@ -96,10 +137,17 @@ endef
 
 .cookiecutter/state/setup-git:
 	@echo -n "Installing and configuring git pre-commit hooks"
+ifeq ($(ENVIRONMENT_TYPE),conda)
 	@(eval "$$(conda shell.bash activate "${REPO_NAME}")"\
-	 &&pre-commit install --install-hooks)\
+	 && pre-commit install --install-hooks)\
 	 > $@.log 2>&1\
 	 || $(call err,Git pre-commit setup failed)
+else
+	@($(VENV_ACTIVATE_CMD)\
+	 && pre-commit install --install-hooks)\
+	 > $@.log 2>&1\
+	 || $(call err,Git pre-commit setup failed)
+endif
 	@touch $@
 	@echo " DONE"
 

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -14,37 +14,15 @@ export
 # Import config variables
 include .cookiecutter/config
 
-# Environment type detection
-ENVIRONMENT_TYPE ?= venv
-
-# Virtual environment configuration
-# These can be overridden through environment variables or .envrc
-# Example for pyenv-virtualenv users:
-#   export VENV_PATH=${PYENV_ROOT}/versions/${REPO_NAME}
-#   export VENV_CREATE_CMD="pyenv virtualenv ${PYTHON_VERSION} ${REPO_NAME}"
-#   export VENV_ACTIVATE_CMD="pyenv activate ${REPO_NAME}"
-#   export VENV_DEACTIVATE_CMD="pyenv deactivate"
-VENV_PATH ?= .venv
-VENV_CREATE_CMD ?= python -m venv ${VENV_PATH}
-VENV_ACTIVATE_CMD ?= source ${VENV_PATH}/bin/activate
-VENV_DEACTIVATE_CMD ?= deactivate
-VENV_REMOVE_CMD ?= rm -rf ${VENV_PATH}
-
 # Ensure directory to track and log setup state exists
 $(shell mkdir -p .cookiecutter/state)
-$(shell touch .cookiecutter/state/conda-create.log)
-$(shell touch .cookiecutter/state/venv-create.log)
+$(shell touch .cookiecutter/state/python-env-create.log)
 
 .PHONY: install
-## Install a project: setup environment, install dependencies, and configure git hooks
+## Install the project: setup environment, install dependencies, and configure git hooks
 install:
-ifeq ($(ENVIRONMENT_TYPE),conda)
-	$(MAKE) conda-remove .cookiecutter/state/conda-create .cookiecutter/state/setup-git
-else
-	$(MAKE) venv-remove .cookiecutter/state/venv-create .cookiecutter/state/setup-git
-endif
-	@direnv reload  # Reload to activate the environment
-
+    $(MAKE) python-env-remove .cookiecutter/state/python-env-create .cookiecutter/state/setup-git
+    @direnv reload
 
 .PHONY: check-bucket-path
 check-bucket-path:
@@ -72,24 +50,33 @@ docs-clean:
 docs-open:
 	$(OPEN) docs/_build/index.html
 
-.PHONY: conda-update
-## Update the conda-environment based on changes to `environment.yaml`
-conda-update:
-	conda env update -n ${REPO_NAME} -f environment.yaml
-	$(MAKE) -s pip-install
-	direnv reload
+.PHONY: python-env-create
+## Create the virtual environment
+python-env-create:
+    @echo "Creating ${ENVIRONMENT_TYPE} environment..."
+    @${ENV_CREATE}
+
+.PHONY: python-env-remove
+## Remove the virtual environment
+python-env-remove:
+    @echo "Removing ${ENVIRONMENT_TYPE} environment..."
+    -@${ENV_DEACTIVATE} 2>/dev/null || true
+    -@${ENV_REMOVE} 2>/dev/null || true
+    @rm -f .cookiecutter/state/python-env-create*
+    @direnv reload
+
+.PHONY: python-env-update
+## Update the environment based on dependency files
+python-env-update:
+    @echo "Updating ${ENVIRONMENT_TYPE} environment..."
+    @${ENV_UPDATE}
+    $(MAKE) -s pip-install
+    @direnv reload
 
 .PHONY: pip-install
-## Install our package and requirements in editable mode (including development dependencies)
+## Install package in editable mode with dev dependencies
 pip-install:
-	@pip install -e ".[dev]"
-
-.PHONY: conda-remove
-## Remove the conda-environment cleanly, using -f so works even if no environment to be removed
-conda-remove:
-	conda env remove -n ${REPO_NAME}
-	rm -f .cookiecutter/state/conda-create*
-	@direnv reload
+    @pip install -e ".[dev]"
 
 .PHONY: clean
 ## Delete all compiled Python files
@@ -106,50 +93,27 @@ define err
 	(echo "$1, check $@.log for more info" && exit 1)
 endef
 
-.PHONY: venv-remove
-## Remove the virtual environment cleanly
-venv-remove:
-	rm -rf ${VENV_PATH}
-	rm -f .cookiecutter/state/venv-create*
-	@direnv reload
-
-.cookiecutter/state/venv-create:
-	@echo -n "Creating virtual environment and installing dependencies"
-	@( \
-		$(VENV_CREATE_CMD) && \
-		$(VENV_ACTIVATE_CMD) && \
-		pip install -r requirements.txt && \
-		pip install -e ".[dev]" \
-	) > $@.log 2>&1 \
-	|| $(call err,Python environment setup failed)
-	@touch $@
-	@echo " DONE"
-
-.cookiecutter/state/conda-create:
-	@echo -n "Creating environment ${REPO_NAME} and installing all dependencies"
-	@(conda env create -q -n ${REPO_NAME} -f environment.yaml\
-	  && eval "$$(conda shell.bash activate "${REPO_NAME}")"\
-	  && pip install -e ".[dev]")\
-	 > $@.log 2>&1\
-	 || $(call err,Python environment setup failed)
-	@touch $@
-	@echo " DONE"
+.cookiecutter/state/python-env-create:
+    @echo -n "Creating ${ENVIRONMENT_TYPE} environment and installing dependencies"
+    @( \
+        ${ENV_CREATE} && \
+        ${ENV_ACTIVATE} && \
+        ${ENV_INSTALL_EXTRAS} && \
+        pip install -e ".[dev]" \
+    ) > $@.log 2>&1 \
+    || (echo "Environment setup failed, check $@.log for details" && exit 1)
+    @touch $@
+    @echo " DONE"
 
 .cookiecutter/state/setup-git:
-	@echo -n "Installing and configuring git pre-commit hooks"
-ifeq ($(ENVIRONMENT_TYPE),conda)
-	@(eval "$$(conda shell.bash activate "${REPO_NAME}")"\
-	 && pre-commit install --install-hooks)\
-	 > $@.log 2>&1\
-	 || $(call err,Git pre-commit setup failed)
-else
-	@($(VENV_ACTIVATE_CMD)\
-	 && pre-commit install --install-hooks)\
-	 > $@.log 2>&1\
-	 || $(call err,Git pre-commit setup failed)
-endif
-	@touch $@
-	@echo " DONE"
+    @echo -n "Installing and configuring git pre-commit hooks"
+    @( \
+        ${ENV_ACTIVATE} && \
+        pre-commit install --install-hooks \
+    ) > $@.log 2>&1 \
+    || (echo "Git pre-commit setup failed, check $@.log for details" && exit 1)
+    @touch $@
+    @echo " DONE"
 
 
 #################################################################################


### PR DESCRIPTION
Resolves #199 by allowing cookiecutter to specify the virtual environment management solution and then providing template commands that generalise in the makefile meaning per-project the user can specify their preference and `make install` will automatically set it up in the same way.

---

Checklist:

- [ ] Updated documentation
- [ ] CI passes
- [ ] Labelled PR major/minor/patch
