### PR TITLE
Improve end of user journey docs and auto push to github / set remote if specified

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,10 +1,11 @@
 {
   "project_name": "Project Name",
   "module_name": "{{ cookiecutter.project_name.lstrip('0123456789.- ').replace(' ', '_').replace('-', '_').lower() }}",
+  "repo_url": "",
   "description": "A short description of the project.",
   "openness": ["public", "private"],
-  "python_version": "3.13",
   "venv_type": ["uv", "venv", "conda"],
+  "python_version": "3.13",
   "file_structure": ["standard", "simple", "full"],
   "autosetup": ["yes", "no"]
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,18 +1,16 @@
 # Project Set Up
 
-## Your Guide to Setting Up a Nesta Cookiecutter Project
+In this page you will learn how to set up / work with a project using the cookiecutter. The steps are different depending on whether [you are the one setting up a project](#setting-up-a-new-project) or whether a project already exists and [you are just cloning it to set it up for yourself](#working-with-an-existing-project).
 
-In this page you will learn how to set up a project using the cookiecutter. The steps are different depending on whether you are the first one setting up a project ([Project Configurer](#project-configuration)) or whether a project already exists and you are just setting it up locally ([Team Member](#team-members)).
+## Setting up a new project
 
-### Project Configuration
+_**Prerequisite**: If this is your first time setting up a cookiecutter project you need to install it from https://pypi.org/project/cookiecutter. You can do this in the terminal on macOS with `brew install cookiecutter`._
 
-_**Prerequisite**: If this is your first time setting up a cookiecutter project you need to install it from https://pypi.org/project/cookiecutter. You can do this in the terminal with `brew install cookiecutter`._
-
-#### 1. Request repository setup
+### 1. Request repository setup
 
 First things first, you need a repo created for you. From the [tech support website](https://nestagroup.atlassian.net/servicedesk/customer/portals), go to _Ask Nesta Technology_, _Request Forms_, then _Request GitHub repository_. You will need to provide a _project name_, _repo name_, whether _public/private_, _github teams involved_, _team leading the project_, _short and long description of the project_. An empty repo will automatically be set up for you within a few minutes: https://github.com/nestauk/your_repo_name. Your team should have admin access on the repository.
 
-#### 2. Set up your project locally
+### 2. Set up your project locally
 
 It is important that you _do not clone the repo yet!_ Instead, open the terminal and `cd` to a folder where you eventually want your repo to be, then run the cookiecutter:
 
@@ -31,21 +29,30 @@ You will be prompted to enter the following information:
 -   `You've downloaded ~.cookiecutters/ds-cookiecutter before. Is it okay to delete and re-download it?[yes]` press Enter to confirm yes, it's always best to use the latest version.
 -   `project_name [project_name]`: Enter the title of your project. This will be used in the `README.md` file and docs.
 -   `module_name [project_name]`: This defaults to a sanitised (lower-case, no spaces, no numbers) version of the project name (used in `pyproject.toml` and throughout).
-<!-- -   `repo_url []`: This is the URL of the repo you created in step 1. If left blank, no attempt will be made to connect the local project to the remote repo. -->
+-   `repo_url []`: This is the URL / SSH address of the repo you created in step 1 (starts with `git@github` or `https://github` respectively). If left blank, no attempt will be made to connect the local project to the remote repo.
 -   `description [A short description of the project.]`: Add a short description
--   `openness [public]`: This determines the licence, this can be changed in the future if needed
--   `python_version [3.13]`: the behaviour of this prompt depends on the `venv_type` you selected. If you selected `uv` you may provide a PEP compliant expression for the `pyproject.toml` (e.g. `>=3.10`, `==3.11.*`, etc.). If you selected `venv` it must be a single version available on your system (e.g. `3.10`, `3.11`, etc.). If you selected `conda`, you needn't have the version installed but again you must specify a single version (e.g. `3.10`, `3.10.2`, etc.). The `pyproject.toml` will be created with the specified version.
+-   `openness [public]`: This determines the licence and can be changed in the future if needed
 -   `venv_type [uv]`: choose how you will manage your virtual environment, the options are [`uv`](https://docs.astral.sh/uv/), [`venv`](https://docs.python.org/3/library/venv.html) or [`conda`](https://docs.conda.io/en/latest/).
+-   `python_version [3.13]`: The behaviour of this prompt depends on the `venv_type` you selected. If you selected `uv` you may provide a PEP compliant expression for the `pyproject.toml` (e.g. `>=3.10`, `==3.11.*`, etc., or just `3.13`). If you selected `venv` it must be a single version that is **available** on your system (e.g. `3.10` if you have it installed). If you selected `conda`, you needn't have the version installed but again you must specify a single version (e.g. `3.10`, `3.10.2`, etc.). The `pyproject.toml` will be created with the specified version.
 -   `file_structure [standard]`: choose the complexity of your project. The options are: `simple` (basic and recommended for small projects); `standard` (a good balance between simplicity and complexity); and `full` (includes folders for documentation and testing).
 -   `autosetup [yes]`: this will automatically set up the project's virtual environment, pre-commit hooks and git repository for you. If you select `no`, you will have to do this manually later.'
 
-#### 3. Connect your local project to github
+### 3. Connect your local project to github
 
-You have set up your project locally and now you have to connect it to the remote repo. When you change directory to your created project folder, you will see that you are in a git repository and the generated cookiecutter has committed itself to the `main` and `dev` branches. Connect to the git repo by running `git remote add origin git@github.com:nestauk/<REPONAME>` to point your local project to the configured repository.
+You have set up your project locally and it now must be connected to the remote repo (if auto-setup has not done this for you, refresh the GitHub repo if unsure). Either way, you will see that your new project has been initialised as a git repository and the cookiecutter has committed itself to the `main` and `dev` branches. You can then connect to the git repo by running `git remote add origin git@github.com:nestauk/<REPONAME>` to point your local project to the configured repository. Then (force) push each branch to the remote repository with, **this will overwrite anything on the remote branches**:
+
+```bash
+git checkout main
+git push --set-upstream --force origin main
+git checkout dev
+git push --set-upstream --force origin dev
+```
 
 **Now you are all set!**
 
-### Team Members
+## Working with an existing project
+
+If you are a team member, you will not need to set up the project from scratch. Instead, you will clone an existing project that has already been set up.
 
 Clone the repository and `cd` into it; you can then ascertain the `venv_type` used in the project's creation. This can be inferred by the presence of a `uv.lock` file for `uv` or an `environment.yaml` file for `conda`.
 

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -5,6 +5,7 @@ VENV_TYPE="{{ cookiecutter.venv_type }}"
 MODULE_NAME="{{ cookiecutter.module_name }}"
 FILE_STRUCTURE="{{ cookiecutter.file_structure }}"
 AUTOSETUP="{{ cookiecutter.autosetup }}"
+REPO_URL="{{ cookiecutter.repo_url }}"
 
 # Different validation logic based on venv_type
 if [ "$VENV_TYPE" = "uv" ]; then
@@ -159,36 +160,29 @@ git add .
 SKIP=no-commit-to-branch git commit -am "Setup Nesta Data Science cookiecutter"
 git checkout -b dev -q
 
-# # Set up remote using the module_name
-# REPO_URL="git@github.com:nestauk/$MODULE_NAME.git"
-
-# # Ask about force pushing
-# read -p "Do you want set up the remote (pointing at $REPO_URL) and force push? The repository must already exist. This will overwrite any existing branches with the contents of the cookiecutter. (y/N) " -n 1 -r FORCE_REPLY
-# echo
-
-# if [[ $FORCE_REPLY =~ ^[Yy]$ ]]; then
-#     echo
-#     echo "WARNING: This operation will overwrite any existing work in the repository."
-#     read -p "Are you sure you want to force push? (y/N) " -n 1 -r CONFIRM_REPLY
-#     echo
-#     if [[ $CONFIRM_REPLY =~ ^[Yy]$ ]]; then
-#         echo "Force pushing branches to remote..."
-#         git remote add origin "$REPO_URL"
-#         git push -f origin main
-#         git push -f origin dev
-#     else
-#         echo "Not pushing to remote. You can manually add the remote later with the following command:"
-#         echo "git remote add origin $REPO_URL"
-#         echo
-#     fi
-# else
-#     echo "Not pushing to remote. You can add the remote manually later with the following command:"
-#     echo "git remote add origin $REPO_URL"
-#     echo
-# fi
-
-echo "Successfully configured git repo at $(pwd)"
+echo "Successfully configured git repo at $(pwd)/.git"
 echo
 
+if [ -n "$REPO_URL" ]; then
+    echo "Setting up remote repository..."
+    git remote add origin "$REPO_URL"
+    echo "WARNING: Do you want to force push your local repository to the remote provided? This operation will overwrite any existing work in the repository!"
+    echo "This is fine if this is just initial setup as the repository should be empty."
+    read -p "Are you sure you want to force push? (y/N) " -n 1 -r CONFIRM_REPLY
+    echo
+    if [[ $CONFIRM_REPLY =~ ^[Yy]$ ]]; then
+        echo "Force pushing branches to remote..."
+        git push -uf origin main
+        git push -uf origin dev
+        echo
+    else
+        echo "Not pushing to remote. You can manually force push the branches later with the following command:"
+        echo "git push -uf origin <BRANCH_NAME>"
+        echo
+    fi
+else
+    echo "No remote repository URL provided. You can set it up later."
+    echo
+fi
 
 echo "Setup complete! You can now start working on your project."

--- a/{{ cookiecutter.module_name }}/pyproject.toml
+++ b/{{ cookiecutter.module_name }}/pyproject.toml
@@ -14,11 +14,11 @@ license = { text = "{% if cookiecutter.openness == 'public' %}MIT{% else %}propr
 readme = "README.md"
 requires-python = "{{ cookiecutter.python_version }}"
 dependencies = []
-
+{% if cookiecutter.repo_url %}
 [project.urls]
-repository = "https://github.com/nestauk/{{ cookiecutter.module_name }}"
-issues = "https://github.com/nestauk/{{ cookiecutter.module_name }}/issues"
-
+repository = "{% if cookiecutter.repo_url.startswith('git@') %}https://{{ cookiecutter.repo_url[4:-4].replace(':', '/') }}{% else %}{{ cookiecutter.repo_url }}{% endif %}"
+issues = "{% if cookiecutter.repo_url.startswith('git@') %}https://{{ cookiecutter.repo_url[4:-4].replace(':', '/') }}{% else %}{{ cookiecutter.repo_url }}{% endif %}/issues"
+{% endif %}
 [dependency-groups]
 dev = ["ipykernel", "jupytext", "ruff", {% if cookiecutter.file_structure == 'full' %}"pytest", {% endif %}"pre-commit"]
 


### PR DESCRIPTION
Had some user feedback that it would be good to automate the remote and force push after all, I add a warning, please try it out with a GitHub repo, you can use this one if you want (https://github.com/nestauk/cookiecutter_sandbox) and decide if you are happy with this being automated too. I think then the last step would just be to get the actual setup sorted (which would make part of this redundant), for now though this feels the clearest and easiest path. Have also just updated the docs in case someone doesn't provide `repo_url`.

Roughly:

- Add a new parameter, `repo_url` to the `cookiecutter.json`
- It defaults to nothing, and the hook script has a line alerting the user that nothing has been done on the remote
- If it is specified, a new (uncommented) part of the hook runs to set the remote
- It then prompts the user with a warning for a force push to the repo provided
- If the user says no it tells them they can do it later
- The `pyproject.toml` automatically specifies the repo's URL and issues page if the user provides the URL, otherwise this section is omitted from the toml

Checklist:

- [x] Updated documentation
- [ ] CI passes
- [x] Labelled PR major/minor/patch
