### PR TITLE
Add GitHub workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: pre-commit-update
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
@@ -17,7 +17,7 @@ repos:
         args: ["-b", dev, "-b", master, "-b", main]
         pass_filenames: false
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.4
+    rev: v0.13.2
     hooks:
       - id: ruff-check
       - id: ruff-format

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -47,6 +47,12 @@ Now, every time you run `git commit`, it should perform these checks automatical
 
 **Warning:** You need to run `git commit` with your virtual environment activated. This is because by default the packages used by pre-commit are installed into your project's environment. (note: `pre-commit install --install-hooks` will install the pre-commit hooks in the currently active environment, which is why we source it before running in the example above).
 
+## GitHub Actions
+
+Since `pre-commit` runs locally on individual machines, we have also put in GitHub Actions to ensure that the `pre-commit` checks are also run on any pull requests, and any pushes
+to `dev` or `main`. These should be used by reviewers to ensure that any code meets the standards set in the `pre-commit-config.yaml` prior to merging. Given `pre-commit` is setup
+by default with the project, no manual setup should be required. Every time you update `pre-commit`, these checks will be reflected and run in GitHub Actions.
+
 ## Reproducible environment
 
 The first step in reproducing someone else’s analysis is to reproduce the computational environment it was run in. You need the same tools, the same libraries, and the same versions to make everything play nicely together.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ds-cookiecutter"
-version = "0.6.1"
+version = "0.6.2"
 description = "DSP cookiecutter template"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "ds-cookiecutter"
-version = "0.6.0"
+version = "0.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "cookiecutter" },

--- a/{{ cookiecutter.module_name }}/.github/workflows/pre-commit.yaml
+++ b/{{ cookiecutter.module_name }}/.github/workflows/pre-commit.yaml
@@ -1,0 +1,21 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up pre-commit
+        run: uv tool install pre-commit
+
+      - name: Run pre-commit on all files
+        run: uv run pre-commit run --all-files


### PR DESCRIPTION
Addresses #246. Really simple change, and decided it actually would be better to just run `pre-commit` on the GitHub remote. This means that people can focus on simply updating their `pre-commit-config.yaml` with any standards for their project, and the GitHub Actions will already be synced to that. Ideally we could use [pre-commit.ci](https://pre-commit.ci/) but that would require giving permission to it from our org, so easier solution is GHA setup manually for each project I think.

Checklist:

- [x] Updated documentation
- [] CI passes
- [x] Labelled PR major/minor/patch
